### PR TITLE
Nurse reset fix

### DIFF
--- a/data/scripts/cable_club.inc
+++ b/data/scripts/cable_club.inc
@@ -1258,7 +1258,7 @@ EventScript_CloseMossdeepGameCornerBarrier::
 	return
 
 CableClub_OnResume:
-@	special InitUnionRoom
+	special InitUnionRoom
 	end
 
 MossdeepCity_GameCorner_1F_EventScript_InfoMan2::


### PR DESCRIPTION
~~Don't know when or why this was commented out but `InitUnionRoom` is responsible for initializing `sUnionRoomPlayerName` to an empty string and not doing so causes `BufferUnionRoomPlayerName` to think there's indeed a union player name set, which the nurse script then interprets as the player being in a union room.~~

#17 